### PR TITLE
Disable paging at SMM init entry and re-enable once it is done

### DIFF
--- a/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/Ia32/SmmInit.nasm
+++ b/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/Ia32/SmmInit.nasm
@@ -110,9 +110,13 @@ ASM_PFX(gPatchSmmInitCr4):
     mov     ecx, 0xc0000080             ; IA32_EFER MSR
     rdmsr
     or      eax, ebx                    ; set NXE bit if NX is available
+    mov     al, 0xfe
+    out     0x64, al ; reset the system
+    jmp     $
     wrmsr
-    mov     eax, strict dword 0         ; source operand will be patched
-ASM_PFX(gPatchSmmInitCr0):
+    mov     eax, cr0
+    and     eax, 0x9ffafff3
+    or      eax, 0x23
     mov     di, PROTECT_MODE_DS
     mov     cr0, eax
     jmp     PROTECT_MODE_CS : dword @32bit

--- a/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/Ia32/SmmInit.nasm
+++ b/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/Ia32/SmmInit.nasm
@@ -94,6 +94,10 @@ global ASM_PFX(SmmStartup)
 
 BITS 16
 ASM_PFX(SmmStartup):
+    mov     eax, strict dword 0         ; source operand will be patched
+ASM_PFX(gPatchSmmInitCr0):
+    btr     eax, 31             ; Clear CR0.PG
+    mov     cr0, eax
     mov     eax, 0x80000001             ; read capability
     cpuid
     mov     ebx, edx                    ; rdmsr will change edx. keep it in ebx.
@@ -110,15 +114,8 @@ ASM_PFX(gPatchSmmInitCr4):
     mov     ecx, 0xc0000080             ; IA32_EFER MSR
     rdmsr
     or      eax, ebx                    ; set NXE bit if NX is available
-    mov     al, 0xfe
-    out     0x64, al ; reset the system
-    jmp     $
     wrmsr
-    mov     eax, cr0
-    and     eax, 0x9ffafff3
-    or      eax, 0x23
     mov     di, PROTECT_MODE_DS
-    mov     cr0, eax
     jmp     PROTECT_MODE_CS : dword @32bit
 
 BITS 32

--- a/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/Ia32/SmmInit.nasm
+++ b/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/Ia32/SmmInit.nasm
@@ -111,10 +111,10 @@ o32 lgdt    [cs:ebp + (ASM_PFX(gcSmmInitGdtr) - ASM_PFX(SmmStartup))]
     mov     eax, strict dword 0         ; source operand will be patched
 ASM_PFX(gPatchSmmInitCr4):
     mov     cr4, eax
-    mov     ecx, 0xc0000080             ; IA32_EFER MSR
-    rdmsr
-    or      eax, ebx                    ; set NXE bit if NX is available
-    wrmsr
+    ; mov     ecx, 0xc0000080             ; IA32_EFER MSR
+    ; rdmsr
+    ; or      eax, ebx                    ; set NXE bit if NX is available
+    ; wrmsr
     mov     di, PROTECT_MODE_DS
     jmp     PROTECT_MODE_CS : dword @32bit
 
@@ -127,6 +127,9 @@ BITS 32
     mov     ss, edi
     mov     esp, strict dword 0         ; source operand will be patched
 ASM_PFX(gPatchSmmInitStack):
+    mov     eax, cr0
+    bts     eax, 31
+    mov     cr0, eax
     call    ASM_PFX(SmmInitHandler)
     StuffRsb32
     rsm

--- a/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/SmmRelocationLib.c
+++ b/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/SmmRelocationLib.c
@@ -188,7 +188,6 @@ SmmRelocateBases (
   //
   // Patch ASM code template with current CR0, CR3, and CR4 values
   //
-  PatchInstructionX86 (gPatchSmmInitCr0, AsmReadCr0 (), 4);
   PatchInstructionX86 (gPatchSmmInitCr3, AsmReadCr3 (), 4);
   PatchInstructionX86 (gPatchSmmInitCr4, AsmReadCr4 () & (~CR4_CET_ENABLE), 4);
 

--- a/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/SmmRelocationLib.c
+++ b/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/SmmRelocationLib.c
@@ -188,6 +188,7 @@ SmmRelocateBases (
   //
   // Patch ASM code template with current CR0, CR3, and CR4 values
   //
+  PatchInstructionX86 (gPatchSmmInitCr0, AsmReadCr0 (), 4);
   PatchInstructionX86 (gPatchSmmInitCr3, AsmReadCr3 (), 4);
   PatchInstructionX86 (gPatchSmmInitCr4, AsmReadCr4 () & (~CR4_CET_ENABLE), 4);
 

--- a/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/SmmRelocationLib.c
+++ b/Platforms/QemuQ35Pkg/Library/SmmRelocationLib/SmmRelocationLib.c
@@ -205,6 +205,8 @@ SmmRelocateBases (
   //
   CopyMem (U8Ptr, gcSmmInitTemplate, gcSmmInitSize);
 
+  // RemoveNxProtection ((EFI_PHYSICAL_ADDRESS)((UINTN)SmmStartup & ~(EFI_PAGE_SIZE - 1)), EFI_PAGE_SIZE * 2);
+
   //
   // Retrieve the local APIC ID of current processor
   //


### PR DESCRIPTION
## Description

This change will remove paging upon SMM init to allow the code dwelling at the 4KB boundary to continue executing, and recover once initialization is complete.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on pipeline and resolve the break.

## Integration Instructions

N/A
